### PR TITLE
Get a std::path::PathBuf from file URLs

### DIFF
--- a/stormlicht/src/browser_application.rs
+++ b/stormlicht/src/browser_application.rs
@@ -10,7 +10,7 @@ const INITIAL_WIDTH: u16 = 800;
 const INITIAL_HEIGHT: u16 = 600;
 
 const WELCOME_PAGE: &str = concat!(
-    "file://localhost",
+    "file://localhost/",
     env!("CARGO_MANIFEST_DIR"),
     "/../pages/welcome.html"
 );


### PR DESCRIPTION
This allows us to directly get a PathBuf from a file url. Before, you would need to iterate over the path segments of the url and build your own path - because this needs to be platform specific, its better to have dedicated methods inside URL.

The unix version still needs testing as I'm currently on windows (:

When completed, this will fix #4 